### PR TITLE
docs: quickstart bug fix

### DIFF
--- a/docs/_content/overview/quickstart.md
+++ b/docs/_content/overview/quickstart.md
@@ -158,7 +158,9 @@ yarn add @gramps/gramps apollo-server-express body-parser graphql
   }
   
   const app = Express();
-+ const GraphQLOptions = gramps();
++ const GraphQLOptions = gramps({
++   dataSources: []    
++ });
   
 - app.get('/', (_, res) => res.send('Hello world!'));
 + app.use(bodyParser.json());


### PR DESCRIPTION
Looks like you need to pass it an empty array or it throws an error.