### PR TITLE
Added support for async context function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,21 @@ const Express = require('express');
 const bodyParser = require('body-parser');
 const gramps = require('@gramps/gramps').default;
 const { GraphQLSchema } = require('graphql');
-const { graphqlExpress, graphiqlExpress } = require('apollo-server-express');
+const { ApolloServer } = require('apollo-server-express');
 
 const app = Express();
 const GraphQLOptions = gramps();
 
 app.use(bodyParser.json());
-app.use('/graphql', graphqlExpress(GraphQLOptions));
-app.use('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }));
+const server = new ApolloServer(GraphQLOptions)
+server.applyMiddleware({ app, path: '/graphql' })
 
-app.listen(8080, () => console.log(`=> running at http://localhost:8080/`));
+app.listen({ port: 8080 }, () =>
+  console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`)
+)
 ```
 
-Start the server with `node index.js`, then open http://localhost:8080/graphiql to see the GraphiQL user interface.
+Start the server with `node index.js`, then open http://localhost:8080/graphql to see the GraphiQL user interface.
 
 For a more in-depth starter, [see the 5-minute quickstart](https://gramps.js.org/overview/quickstart/) in our documentation.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const server = new ApolloServer(GraphQLOptions)
 server.applyMiddleware({ app, path: '/graphql' })
 
 app.listen({ port: 8080 }, () =>
-  console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`)
+  console.log(`🚀 Server ready at http://localhost:8080${server.graphqlPath}`)
 )
 ```
 

--- a/src/gramps.js
+++ b/src/gramps.js
@@ -167,6 +167,6 @@ export default function gramps(...args) {
 
   return {
     ...options,
-    context: ({ req } = {}) => options.context(req),
+    context: ({ req, connection } = {}) => options.context({ req, connection }),
   };
 }

--- a/src/gramps.js
+++ b/src/gramps.js
@@ -137,19 +137,17 @@ export function prepare({
     resolvers,
   });
 
-  const getContext = req => {
-    const extra = extraContext(req);
-    return sources.reduce((allContext, source) => {
+  const getContext = async req => {
+    const extra = await extraContext(req);
+    const allContext = {};
+    for (const source of sources) {
       const sourceContext =
         typeof source.context === 'function'
-          ? source.context(req)
+          ? await source.context(req)
           : source.context;
-
-      return {
-        ...allContext,
-        [source.namespace]: { ...extra, ...sourceContext },
-      };
-    }, extra);
+      allContext[source.namespace] = { ...extra, ...sourceContext };
+    }
+    return allContext;
   };
 
   return {

--- a/src/gramps.js
+++ b/src/gramps.js
@@ -165,9 +165,5 @@ export function prepare({
 }
 
 export default function gramps(...args) {
-  const options = prepare(...args);
-  return req => ({
-    ...options,
-    context: options.context(req),
-  });
+  return prepare(...args);
 }

--- a/test/gramps.test.js
+++ b/test/gramps.test.js
@@ -62,13 +62,8 @@ describe('GrAMPS', () => {
   describe('gramps()', () => {
     it('creates a valid schema and empty context with no arguments', () => {
       const getGrampsContext = gramps();
-
-      expect(getGrampsContext()).toEqual(
-        expect.objectContaining({
-          schema: expect.any(GraphQLSchema),
-          context: {},
-        }),
-      );
+      expect(getGrampsContext.context()).toEqual({});
+      expect(getGrampsContext.schema).toBeInstanceOf(GraphQLSchema);
     });
 
     it('warns for use of schema', () => {
@@ -114,9 +109,9 @@ describe('GrAMPS', () => {
         },
       ];
 
-      const grampsConfig = gramps({ dataSources, enableMockData: false })();
+      const grampsConfig = gramps({ dataSources, enableMockData: false });
 
-      expect(grampsConfig.context).toEqual({
+      expect(grampsConfig.context()).toEqual({
         Foo: {
           foo: 'test',
         },
@@ -133,9 +128,9 @@ describe('GrAMPS', () => {
       const grampsConfig = gramps({
         dataSources: [{ namespace: 'FOO', context: { source: 'context' } }],
         extraContext: () => ({ extra: 'context' }),
-      })();
+      });
 
-      expect(grampsConfig.context).toEqual({
+      expect(grampsConfig.context()).toEqual({
         FOO: { extra: 'context', source: 'context' },
         extra: 'context',
       });
@@ -155,7 +150,7 @@ describe('GrAMPS', () => {
           },
         ],
         enableMockData: true,
-      })();
+      });
 
       // The first call is the GrAMPS root data source, which has no mocks.
       expect(spy.mock.calls[1][0].mocks).toEqual({

--- a/test/gramps.test.js
+++ b/test/gramps.test.js
@@ -13,7 +13,7 @@ describe('GrAMPS', () => {
       const next = jest.genMockFn();
       const req = {};
       addContext(req, {}, next);
-      expect(req).toEqual({ gramps: {} });
+      expect(req.gramps).resolves.toEqual({});
       expect(next).toBeCalled();
     });
 
@@ -115,8 +115,7 @@ describe('GrAMPS', () => {
       ];
 
       const grampsConfig = gramps({ dataSources, enableMockData: false });
-
-      expect(grampsConfig.context()).toEqual({
+      expect(grampsConfig.context()).resolves.toEqual({
         Foo: {
           foo: 'test',
         },
@@ -135,7 +134,7 @@ describe('GrAMPS', () => {
         extraContext: () => ({ extra: 'context' }),
       });
 
-      expect(grampsConfig.context()).toEqual({
+      expect(grampsConfig.context()).resolves.toEqual({
         FOO: { extra: 'context', source: 'context' },
         extra: 'context',
       });


### PR DESCRIPTION
I couldn't find it in apollo-server docs anywhere, but the `context` option for the server - when it's a function - accepts returning the context object as a promise.
So, I added support for it inside gramps datasources and extraContext too.

**Edit** found an example of async context here: https://www.apollographql.com/docs/apollo-server/features/subscriptions.html#Context-with-Subscriptions