### PR TITLE
feat(remoteSchemas): add prefixes as an option for remote schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "apollo-link-http": "^1.5.11",
     "chalk": "^2.1.0",
     "graphql-tag": "^2.10.1",
-    "graphql-tools": "^2.20.2",
+    "graphql-tools": "^4.0.5",
     "graphql-upload": "^8.0.0",
     "isomorphic-fetch": "^2.2.1"
   },
@@ -71,6 +71,7 @@
     "travis-deploy-once": "^4.3.4"
   },
   "jest": {
+    "testURL": "http://localhost",
     "coverageReporters": [
       "json",
       "text",

--- a/src/gramps.js
+++ b/src/gramps.js
@@ -134,9 +134,8 @@ export async function prepare({
   );
 
   const remoteSources = sources.filter(source => source.remoteSchema);
-  const remoteSchemaURLs = remoteSources.map(source => source.remoteSchema);
 
-  const remoteSchemas = await handleRemoteSchemas(remoteSchemaURLs);
+  const remoteSchemas = await handleRemoteSchemas(remoteSources);
 
   const schema = mergeSchemas({
     schemas: [...schemas, ...linkTypeDefs, ...remoteSchemas],

--- a/test/lib/handleRemoteSchemas.test.js
+++ b/test/lib/handleRemoteSchemas.test.js
@@ -12,7 +12,10 @@ describe('lib/handleRemoteSchemas', () => {
 
     const remoteSchema = await handleRemoteSchemas([
       {
-        url: 'http://coolremotegraphqlserver.com/graphql',
+        namespace: 'coolremotegraphqlserver',
+        remoteSchema: {
+          url: 'http://coolremotegraphqlserver.com/graphql',
+        },
       },
     ]);
 
@@ -27,16 +30,38 @@ describe('lib/handleRemoteSchemas', () => {
 
     const remoteSchema = await handleRemoteSchemas([
       {
-        url: 'http://coolremotegraphqlserver.com/graphql',
-        setContextCallback: () => ({
-          headers: {
-            Authorization: '123',
-          },
-        }),
+        namespace: 'coolremotegraphqlserver',
+        remoteSchema: {
+          url: 'http://coolremotegraphqlserver.com/graphql',
+          setContextCallback: () => ({
+            headers: {
+              Authorization: '123',
+            },
+          }),
+        },
       },
     ]);
 
     expect(fetchMock._calls[0][1].headers.Authorization).toBe('123');
+  });
+
+  it('adds prefixes if a prefix is set', async () => {
+    fetchMock.mock(
+      'http://coolremotegraphqlserver.com/graphql',
+      remoteIntrospectionSchema,
+    );
+
+    const remoteSchema = await handleRemoteSchemas([
+      {
+        namespace: 'coolremotegraphqlserver',
+        remoteSchema: {
+          url: 'http://coolremotegraphqlserver.com/graphql',
+          prefix: 'CRG',
+        },
+      },
+    ]);
+
+    expect(remoteSchema[0]._typeMap.CRG_Book).toBeTruthy();
   });
 
   it('handles errors if the url is failing', async () => {
@@ -48,10 +73,16 @@ describe('lib/handleRemoteSchemas', () => {
 
     const remoteSchema = await handleRemoteSchemas([
       {
-        url: 'http://coolremotegraphqlserver.com/graphql',
+        namespace: 'coolremotegraphqlserver',
+        remoteSchema: {
+          url: 'http://coolremotegraphqlserver.com/graphql',
+        },
       },
       {
-        url: 'http://coolremotegraphqlserver2.com/graphql',
+        namespace: 'coolremotegraphqlserver',
+        remoteSchema: {
+          url: 'http://coolremotegraphqlserver2.com/graphql',
+        },
       },
     ]);
 


### PR DESCRIPTION
Allows a prefix property to be defined in a remoteSchema config that will then prefix all types to avoid any naming collisions.

If a prefix is specified queries and mutations will also be prefixed with the namespace.